### PR TITLE
Hex publish needs OTP 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:23.0-alpine
+FROM erlang:24.0-alpine
 
 # These dependencies are required for `rebar3 edoc` (see entrypoint.sh), which compiles the source.
 RUN apk add --no-cache bsd-compat-headers gcc git libc-dev make


### PR DESCRIPTION
This should fix the following error:

```
Before publishing, please read Hex CoC: https://hex.pm/policies/codeofconduct
===> Published cowmachine 1.10.0
===> You are using erlang/OTP '23', but this plugin requires at least erlang/OTP 24.
```