### PR TITLE
Switch to erlang:24 Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM erlang:24.0-alpine
-
-# These dependencies are required for `rebar3 edoc` (see entrypoint.sh), which compiles the source.
-RUN apk add --no-cache bsd-compat-headers gcc git libc-dev make
+FROM erlang:24
 
 COPY rebar.config /rebar3/.config/rebar3/rebar.config
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
This removes the need to install separate packages and ensures a compatible git version.